### PR TITLE
Fix the errant behavior of calendar markup

### DIFF
--- a/js/jquery.dateRange.js
+++ b/js/jquery.dateRange.js
@@ -192,7 +192,9 @@
                     container.append(generateCalendar(dateRange.startDate));
                     container.append(generateCalendar(dateRange.endDate));
                 } else {
-                    container = $(generateCalendar(startDate));
+                    container = $(options.calendarContainer);
+                    container = container.append($(generateCalendar(startDate)));
+
                 }
 
                 container.hover(


### PR DESCRIPTION
When the rangePicker is false, the calendar style is broken because container tag is not in place. This should fix that.
